### PR TITLE
Jwt token validation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,22 @@ engine = create_async_engine(TEST_DATABASE_URL, echo=settings.debug)
 AsyncTestingSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 AsyncSessionScoped = scoped_session(AsyncTestingSessionLocal)
 
+@pytest.fixture
+def async_client():
+    client = TestClient(app)
+    return client
+
+@pytest.fixture
+def user_token():
+    return create_access_token(data={"sub": "john_doe", "role": UserRole.AUTHENTICATED.value})
+
+@pytest.fixture
+def admin_token():
+    return create_access_token(data={"sub": "admin_member", "role": UserRole.ADMIN.value})
+
+@pytest.fixture
+def manager_token():
+    return create_access_token(data={"sub": "manager_chris", "role": UserRole.MANAGER.value})
 
 @pytest.fixture
 def email_service():
@@ -217,6 +233,7 @@ def user_base_data():
     return {
         "username": "john_doe_123",
         "email": "john.doe@example.com",
+        "nickname": "JohnnyD",
         "full_name": "John Doe",
         "bio": "I am a software engineer with over 5 years of experience.",
         "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg"
@@ -241,6 +258,7 @@ def user_create_data(user_base_data):
 def user_update_data():
     return {
         "email": "john.doe.new@example.com",
+        "first_name": "John",
         "full_name": "John H. Doe",
         "bio": "I specialize in backend development with Python and Node.js.",
         "profile_picture_url": "https://example.com/profile_pictures/john_doe_updated.jpg"
@@ -249,7 +267,7 @@ def user_update_data():
 @pytest.fixture
 def user_response_data():
     return {
-        "id": "unique-id-string",
+        "id": uuid4(),
         "username": "testuser",
         "email": "test@example.com",
         "last_login_at": datetime.now(),
@@ -260,4 +278,4 @@ def user_response_data():
 
 @pytest.fixture
 def login_request_data():
-    return {"username": "john_doe_123", "password": "SecurePassword123!"}
+    return {"username": "john_doe_123","email":"john.doe@example.com", "password": "SecurePassword123!"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ Fixtures:
 - `token`: Generates an authentication token for testing secured endpoints.
 - `initialize_database`: Prepares the database at the session start.
 - `setup_database`: Sets up and tears down the database before and after each test.
+
 """
 
 # Standard library imports

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -1,4 +1,5 @@
 from builtins import str
+
 import pytest
 from pydantic import ValidationError
 from datetime import datetime

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -3,6 +3,47 @@ import pytest
 from pydantic import ValidationError
 from datetime import datetime
 from app.schemas.user_schemas import UserBase, UserCreate, UserUpdate, UserResponse, UserListResponse, LoginRequest
+from uuid import UUID
+
+@pytest.fixture
+def user_base_data():
+    return {
+        "nickname": "test_user",
+        "email": "test_user@example.com",
+        "profile_picture_url": "http://example.com/profile.jpg",
+    }
+
+@pytest.fixture
+def user_create_data():
+    return {
+        "nickname": "new_user",
+        "email": "new_user@example.com",
+        "password": "securepassword",
+    }
+
+@pytest.fixture
+def user_update_data():
+    return {
+        "email": "updated_user@example.com",
+        "first_name": "UpdatedName",
+    }
+
+@pytest.fixture
+def user_response_data():
+    return {
+        "id": UUID('550e8400-e29b-41d4-a716-446655440000'),
+        "nickname": "test_user",
+        "email": "test_user@example.com",
+        "profile_picture_url": "http://example.com/profile.jpg",
+        "last_login_at": "2024-12-02T10:00:00Z",
+    }
+
+@pytest.fixture
+def login_request_data():
+    return {
+        "email": "test_user@example.com",
+        "password": "securepassword",
+    }    
 
 # Tests for UserBase
 def test_user_base_valid(user_base_data):


### PR DESCRIPTION
Issue: Failing Tests Due to Missing or Inconsistent Fixtures
Several tests in test_database_operations.py were failing due to:
Missing fields in fixture data, such as nickname and email in login_request_data.
Inconsistent UUID handling in user_response_data.
Incomplete or outdated token generation in fixtures like user_token, admin_token, and manager_token.
Inefficient use of Faker to generate random and consistent user data for tests, leading to flaky tests.
Lack of coverage for specific edge cases, such as invalid email or URL formats.