### PR TITLE
Fix: Add nickname to UserCreate and replace password regex with validator

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -1,5 +1,6 @@
 from builtins import ValueError, any, bool, str
-from pydantic import BaseModel, EmailStr, Field, validator, root_validator
+from pydantic import BaseModel, EmailStr, Field, constr, validator, root_validator
+from typing import Optional
 from typing import Optional, List
 from datetime import datetime
 from enum import Enum
@@ -37,9 +38,25 @@ class UserBase(BaseModel):
     class Config:
         from_attributes = True
 
-class UserCreate(UserBase):
+class UserCreate(BaseModel):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., example="Secure*1234")
+    nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example="john_doe")
+
+    @validator("password")
+    def strong_password(cls, v):
+        import re
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters long.")
+        if not re.search(r"[A-Z]", v):
+            raise ValueError("Password must contain at least one uppercase letter.")
+        if not re.search(r"[a-z]", v):
+            raise ValueError("Password must contain at least one lowercase letter.")
+        if not re.search(r"\d", v):
+            raise ValueError("Password must contain at least one digit.")
+        if not re.search(r"[@$!%*?&]", v):
+            raise ValueError("Password must contain at least one special character (@$!%*?&).")
+        return v
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 
 # Third-party imports
 import pytest
+import uuid
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
@@ -210,54 +211,72 @@ async def manager_user(db_session: AsyncSession):
     await db_session.commit()
     return user
 
-
 # Fixtures for common test data
 @pytest.fixture
 def user_base_data():
     return {
-        "username": "john_doe_123",
+        "nickname": "john_doe",
         "email": "john.doe@example.com",
-        "full_name": "John Doe",
+        "first_name": "John",
+        "last_name": "Doe",
         "bio": "I am a software engineer with over 5 years of experience.",
-        "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg"
+        "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/johndoe",
+        "github_profile_url": "https://github.com/johndoe"
     }
 
 @pytest.fixture
 def user_base_data_invalid():
     return {
-        "username": "john_doe_123",
-        "email": "john.doe.example.com",
-        "full_name": "John Doe",
+        "nickname": "john_doe",
+        "email": "john.doe.example.com",  # Invalid email
+        "first_name": "John",
+        "last_name": "Doe",
         "bio": "I am a software engineer with over 5 years of experience.",
-        "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg"
+        "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/johndoe",
+        "github_profile_url": "https://github.com/johndoe"
     }
-
 
 @pytest.fixture
 def user_create_data(user_base_data):
-    return {**user_base_data, "password": "SecurePassword123!"}
+    return {
+        **user_base_data,
+        "password": "Secure*1234"
+    }
 
 @pytest.fixture
 def user_update_data():
     return {
         "email": "john.doe.new@example.com",
-        "full_name": "John H. Doe",
+        "nickname": "john_updated",
+        "first_name": "John",
+        "last_name": "Updated",
         "bio": "I specialize in backend development with Python and Node.js.",
-        "profile_picture_url": "https://example.com/profile_pictures/john_doe_updated.jpg"
+        "profile_picture_url": "https://example.com/profile_pictures/john_doe_updated.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/johndoe",
+        "github_profile_url": "https://github.com/johndoe"
     }
 
 @pytest.fixture
 def user_response_data():
     return {
-        "id": "unique-id-string",
-        "username": "testuser",
+        "id": uuid.uuid4(),
         "email": "test@example.com",
-        "last_login_at": datetime.now(),
-        "created_at": datetime.now(),
-        "updated_at": datetime.now(),
-        "links": []
+        "nickname": "jane_doe",
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "bio": "QA engineer",
+        "profile_picture_url": "https://example.com/profile.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/janedoe",
+        "github_profile_url": "https://github.com/janedoe",
+        "role": "AUTHENTICATED",
+        "is_professional": True
     }
 
 @pytest.fixture
 def login_request_data():
-    return {"username": "john_doe_123", "password": "SecurePassword123!"}
+    return {
+        "email": "john.doe@example.com",
+        "password": "Secure*1234"
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,6 +242,7 @@ def user_base_data_invalid():
 def user_create_data(user_base_data):
     return {
         **user_base_data,
+        "nickname": "john_doe", 
         "password": "Secure*1234"
     }
 

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -75,3 +75,20 @@ def test_user_create_and_login_example_match():
     
     assert user_create_schema['properties']['email']['example'] == login_schema['properties']['email']['example']
     assert user_create_schema['properties']['password']['example'] == login_schema['properties']['password']['example']
+
+@pytest.mark.parametrize("bad_password", [
+    "short",               # too short
+    "nocapital123!",       # no uppercase
+    "NOLOWERCASE123!",     # no lowercase
+    "NoSpecials123",       # no special character
+    "NoDigits!"            # no digits
+])
+def test_user_create_invalid_passwords(user_base_data, bad_password):
+    data = {**user_base_data, "password": bad_password}
+    with pytest.raises(ValidationError):
+        UserCreate(**data)
+
+def test_user_create_valid_password(user_base_data):
+    data = {**user_base_data, "password": "ValidPass123!"}
+    user = UserCreate(**data)
+    assert user.password == "ValidPass123!"

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -67,3 +67,11 @@ def test_user_base_invalid_email(user_base_data_invalid):
     
     assert "value is not a valid email address" in str(exc_info.value)
     assert "john.doe.example.com" in str(exc_info.value)
+
+
+def test_user_create_and_login_example_match():
+    user_create_schema = UserCreate.schema()
+    login_schema = LoginRequest.schema()
+    
+    assert user_create_schema['properties']['email']['example'] == login_schema['properties']['email']['example']
+    assert user_create_schema['properties']['password']['example'] == login_schema['properties']['password']['example']


### PR DESCRIPTION
This PR resolves Issue #2.

- Explicitly added `nickname` to UserCreate schema to avoid missing attribute errors in tests.
- Replaced Pydantic regex-based password validation with a custom `@validator`, since lookahead patterns are not supported in Pydantic v2.
- Updated test fixtures accordingly.
- All schema-related tests are now passing 
