### PR TITLE
Fix: Corrected duplicate fields in UserListResponse exampleFix/duplicate role userlistresponse

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -62,7 +62,6 @@ class UserResponse(UserBase):
     role: UserRole = Field(default=UserRole.AUTHENTICATED, example="AUTHENTICATED")
     email: EmailStr = Field(..., example="john.doe@example.com")
     nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example=generate_nickname())    
-    role: UserRole = Field(default=UserRole.AUTHENTICATED, example="AUTHENTICATED")
     is_professional: Optional[bool] = Field(default=False, example=True)
 
 class LoginRequest(BaseModel):

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -73,14 +73,24 @@ class ErrorResponse(BaseModel):
     details: Optional[str] = Field(None, example="The requested resource was not found.")
 
 class UserListResponse(BaseModel):
-    items: List[UserResponse] = Field(..., example=[{
-        "id": uuid.uuid4(), "nickname": generate_nickname(), "email": "john.doe@example.com",
-        "first_name": "John", "bio": "Experienced developer", "role": "AUTHENTICATED",
-        "last_name": "Doe", "bio": "Experienced developer", "role": "AUTHENTICATED",
-        "profile_picture_url": "https://example.com/profiles/john.jpg", 
-        "linkedin_profile_url": "https://linkedin.com/in/johndoe", 
-        "github_profile_url": "https://github.com/johndoe"
-    }])
+    items: List[UserResponse] = Field(
+        ...,
+        example=[
+            {
+                "id": uuid.uuid4(),
+                "nickname": generate_nickname(),
+                "email": "john.doe@example.com",
+                "first_name": "John",
+                "last_name": "Doe",
+                "bio": "Experienced developer",
+                "role": "AUTHENTICATED",
+                "profile_picture_url": "https://example.com/profiles/john.jpg",
+                "linkedin_profile_url": "https://linkedin.com/in/johndoe",
+                "github_profile_url": "https://github.com/johndoe",
+                "is_professional": True
+            }
+        ]
+    )
     total: int = Field(..., example=100)
     page: int = Field(..., example=1)
     size: int = Field(..., example=10)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,49 +215,64 @@ async def manager_user(db_session: AsyncSession):
 @pytest.fixture
 def user_base_data():
     return {
-        "username": "john_doe_123",
         "email": "john.doe@example.com",
-        "full_name": "John Doe",
+        "nickname": "john_doe",
+        "first_name": "John",
+        "last_name": "Doe",
         "bio": "I am a software engineer with over 5 years of experience.",
-        "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg"
+        "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/johndoe",
+        "github_profile_url": "https://github.com/johndoe"
     }
-
-@pytest.fixture
-def user_base_data_invalid():
-    return {
-        "username": "john_doe_123",
-        "email": "john.doe.example.com",
-        "full_name": "John Doe",
-        "bio": "I am a software engineer with over 5 years of experience.",
-        "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg"
-    }
-
 
 @pytest.fixture
 def user_create_data(user_base_data):
-    return {**user_base_data, "password": "SecurePassword123!"}
+    return {**user_base_data, "password": "Secure*1234"}
 
 @pytest.fixture
 def user_update_data():
     return {
         "email": "john.doe.new@example.com",
-        "full_name": "John H. Doe",
+        "nickname": "johnny123",
+        "first_name": "John",
+        "last_name": "Doe",
         "bio": "I specialize in backend development with Python and Node.js.",
-        "profile_picture_url": "https://example.com/profile_pictures/john_doe_updated.jpg"
+        "profile_picture_url": "https://example.com/profile_pictures/john_doe_updated.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/johnny",
+        "github_profile_url": "https://github.com/johnny"
     }
 
 @pytest.fixture
 def user_response_data():
+    import uuid, datetime
     return {
-        "id": "unique-id-string",
-        "username": "testuser",
+        "id": uuid.uuid4(),
         "email": "test@example.com",
-        "last_login_at": datetime.now(),
-        "created_at": datetime.now(),
-        "updated_at": datetime.now(),
-        "links": []
+        "nickname": "jane_doe",
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "bio": "QA engineer",
+        "profile_picture_url": "https://example.com/profile.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/janedoe",
+        "github_profile_url": "https://github.com/janedoe",
+        "role": "AUTHENTICATED",
+        "is_professional": True
     }
 
 @pytest.fixture
 def login_request_data():
-    return {"username": "john_doe_123", "password": "SecurePassword123!"}
+    return {"email": "john.doe@example.com", "password": "Secure*1234"}
+
+@pytest.fixture
+def user_base_data_invalid():
+    return {
+        "email": "john.doe.example.com", 
+        "nickname": "john_doe",
+        "first_name": "John",
+        "last_name": "Doe",
+        "bio": "Testing invalid email.",
+        "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/johndoe",
+        "github_profile_url": "https://github.com/johndoe"
+    }
+


### PR DESCRIPTION
Fixes #4

The example dictionary inside the UserListResponse schema had duplicate fields like "bio" and "role", which caused invalid JSON and misleading Swagger docs.

1. Removed duplicates and updated the example block to match the actual UserResponse schema.
2.  Added missing field is_professional.
3.  Confirmed test cases still pass.
