### PR TITLE
Fix: Trim whitespace from optional string fields in UserBase schema

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -1,5 +1,5 @@
 from builtins import ValueError, any, bool, str
-from pydantic import BaseModel, EmailStr, Field, validator, root_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator, validator, root_validator
 from typing import Optional, List
 from datetime import datetime
 from enum import Enum
@@ -31,9 +31,13 @@ class UserBase(BaseModel):
     profile_picture_url: Optional[str] = Field(None, example="https://example.com/profiles/john.jpg")
     linkedin_profile_url: Optional[str] =Field(None, example="https://linkedin.com/in/johndoe")
     github_profile_url: Optional[str] = Field(None, example="https://github.com/johndoe")
-
     _validate_urls = validator('profile_picture_url', 'linkedin_profile_url', 'github_profile_url', pre=True, allow_reuse=True)(validate_url)
  
+    @field_validator("first_name", "last_name", "nickname", "bio", "linkedin_profile_url", "github_profile_url", mode="before")
+    @classmethod
+    def strip_whitespace(cls, v):
+        return v.strip() if isinstance(v, str) else v
+    
     class Config:
         from_attributes = True
 
@@ -64,6 +68,8 @@ class UserResponse(UserBase):
     nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example=generate_nickname())    
     role: UserRole = Field(default=UserRole.AUTHENTICATED, example="AUTHENTICATED")
     is_professional: Optional[bool] = Field(default=False, example=True)
+    last_login_at: Optional[datetime] = Field(default=None, example=datetime.utcnow())
+
 
 class LoginRequest(BaseModel):
     email: str = Field(..., example="john.doe@example.com")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,12 +215,16 @@ async def manager_user(db_session: AsyncSession):
 @pytest.fixture
 def user_base_data():
     return {
-        "username": "john_doe_123",
         "email": "john.doe@example.com",
-        "full_name": "John Doe",
+        "nickname": "john_doe",
+        "first_name": "John",
+        "last_name": "Doe",
         "bio": "I am a software engineer with over 5 years of experience.",
-        "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg"
+        "profile_picture_url": "https://example.com/profile_pictures/john_doe.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/johndoe",
+        "github_profile_url": "https://github.com/johndoe"
     }
+
 
 @pytest.fixture
 def user_base_data_invalid():
@@ -241,23 +245,39 @@ def user_create_data(user_base_data):
 def user_update_data():
     return {
         "email": "john.doe.new@example.com",
-        "full_name": "John H. Doe",
+        "nickname": "johnny123",
+        "first_name": "John",
+        "last_name": "Doe",
         "bio": "I specialize in backend development with Python and Node.js.",
-        "profile_picture_url": "https://example.com/profile_pictures/john_doe_updated.jpg"
+        "profile_picture_url": "https://example.com/profile_pictures/john_doe_updated.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/johnny",
+        "github_profile_url": "https://github.com/johnny"
     }
+
 
 @pytest.fixture
 def user_response_data():
+    import uuid
+    from datetime import datetime
     return {
-        "id": "unique-id-string",
-        "username": "testuser",
+        "id": uuid.uuid4(),  # This must be a valid UUID
         "email": "test@example.com",
-        "last_login_at": datetime.now(),
-        "created_at": datetime.now(),
-        "updated_at": datetime.now(),
-        "links": []
+        "nickname": "jane_doe",
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "bio": "QA engineer",
+        "profile_picture_url": "https://example.com/profile.jpg",
+        "linkedin_profile_url": "https://linkedin.com/in/janedoe",
+        "github_profile_url": "https://github.com/janedoe",
+        "role": "AUTHENTICATED",
+        "is_professional": True,
+        "last_login_at": datetime.utcnow()
     }
+
 
 @pytest.fixture
 def login_request_data():
-    return {"username": "john_doe_123", "password": "SecurePassword123!"}
+    return {
+        "email": "john.doe@example.com",
+        "password": "SecurePassword123!"
+    }

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -26,7 +26,7 @@ def test_user_update_valid(user_update_data):
 def test_user_response_valid(user_response_data):
     user = UserResponse(**user_response_data)
     assert user.id == user_response_data["id"]
-    # assert user.last_login_at == user_response_data["last_login_at"]
+    assert user.last_login_at == user_response_data["last_login_at"]
 
 # Tests for LoginRequest
 def test_login_request_valid(login_request_data):
@@ -67,3 +67,21 @@ def test_user_base_invalid_email(user_base_data_invalid):
     
     assert "value is not a valid email address" in str(exc_info.value)
     assert "john.doe.example.com" in str(exc_info.value)
+
+# Tests for strips
+def test_user_base_strips_whitespace(user_base_data):
+    user_base_data["first_name"] = "  John  "
+    user_base_data["last_name"] = "  Doe "
+    user_base_data["nickname"] = " john_doe "
+    user_base_data["bio"] = "  Backend dev  "
+    user_base_data["linkedin_profile_url"] = "  https://linkedin.com/in/johndoe  "
+    user_base_data["github_profile_url"] = "  https://github.com/johndoe  "
+    
+    user = UserBase(**user_base_data)
+
+    assert user.first_name == "John"
+    assert user.last_name == "Doe"
+    assert user.nickname == "john_doe"
+    assert user.bio == "Backend dev"
+    assert user.linkedin_profile_url == "https://linkedin.com/in/johndoe"
+    assert user.github_profile_url == "https://github.com/johndoe"


### PR DESCRIPTION

This PR adds a field-level validator to automatically strip leading and trailing whitespace from optional string fields in the `UserBase` schema.


- Added a `@field_validator` to sanitize `first_name`, `last_name`, `nickname`, `bio`, `linkedin_profile_url`, and `github_profile_url` before validation.


This prevents user input errors related to accidental whitespace, improves data consistency, and enhances form UX.


Closes #6
