### PR TITLE
Add nickname validation for reserved words and max length with tests

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -40,16 +40,36 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., example="Secure*1234")
+    nickname: Optional[str] = Field(None, min_length=3, max_length=50, pattern=r'^[\w-]+$', example=generate_nickname())
+
+    @validator("nickname", pre=True)
+    def validate_nickname(cls, value):
+        if value:
+            reserved_words = ["admin", "root", "system"]
+            if value.lower() in reserved_words:
+                raise ValueError("Nickname cannot be a reserved word")
+        return value
+
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")
-    nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example="john_doe123")
+    nickname: Optional[str] = Field(None, min_length=3, max_length=50, pattern=r'^[\w-]+$', example="john_doe123")
+    # ... other fields ...
     first_name: Optional[str] = Field(None, example="John")
     last_name: Optional[str] = Field(None, example="Doe")
     bio: Optional[str] = Field(None, example="Experienced software developer specializing in web applications.")
     profile_picture_url: Optional[str] = Field(None, example="https://example.com/profiles/john.jpg")
     linkedin_profile_url: Optional[str] =Field(None, example="https://linkedin.com/in/johndoe")
     github_profile_url: Optional[str] = Field(None, example="https://github.com/johndoe")
+
+
+    @validator("nickname", pre=True)
+    def validate_nickname(cls, value):
+        if value:
+            reserved_words = ["admin", "root", "system"]
+            if value.lower() in reserved_words:
+                raise ValueError("Nickname cannot be a reserved word")
+        return value
 
     @root_validator(pre=True)
     def check_at_least_one_value(cls, values):

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -189,3 +189,27 @@ async def test_list_users_unauthorized(async_client, user_token):
         headers={"Authorization": f"Bearer {user_token}"}
     )
     assert response.status_code == 403  # Forbidden, as expected for regular user
+
+@pytest.mark.asyncio
+async def test_create_user_invalid_nickname(async_client, admin_token):
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    invalid_data = {
+        "email": "test@example.com",
+        "password": "Secure*1234",
+        "nickname": "admin"  # Reserved word
+    }
+    response = await async_client.post("/users/", json=invalid_data, headers=headers)
+    assert response.status_code == 422
+    assert "Nickname cannot be a reserved word" in response.json()["detail"][0]["msg"]
+
+@pytest.mark.asyncio
+async def test_create_user_too_long_nickname(async_client, admin_token):
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    invalid_data = {
+        "email": "test@example.com",
+        "password": "Secure*1234",
+        "nickname": "a" * 51  # Exceeds max length
+    }
+    response = await async_client.post("/users/", json=invalid_data, headers=headers)
+    assert response.status_code == 422
+    assert "String should have at most 50 characters" in response.json()["detail"][0]["msg"]

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -67,3 +67,14 @@ def test_user_base_invalid_email(user_base_data_invalid):
     
     assert "value is not a valid email address" in str(exc_info.value)
     assert "john.doe.example.com" in str(exc_info.value)
+
+@pytest.mark.parametrize("nickname", ["admin", "root", "system"])
+def test_user_create_reserved_nickname(nickname, user_create_data):
+    user_create_data["nickname"] = nickname
+    with pytest.raises(ValidationError):
+        UserCreate(**user_create_data)
+
+def test_user_create_too_long_nickname(user_create_data):
+    user_create_data["nickname"] = "a" * 51
+    with pytest.raises(ValidationError):
+        UserCreate(**user_create_data)


### PR DESCRIPTION
Issue 1  Username Validation
Problem
The nickname field (used as the username) needs robust validation to handle special characters, length constraints, and uniqueness. Currently, app/schemas/user_schemas.py enforces a pattern=r'^[\w-]+$' (alphanumeric, underscore, hyphen) and min_length=3, but additional validation (e.g., max length, reserved words) may be needed.

Solution
Modify Schema
Update UserCreate and UserUpdate in app/schemas/user_schemas.py to enforce a maximum length (e.g., 50, matching the database schema) and check for reserved words.
Check Uniqueness
Already handled in user_service via get_by_nickname, but ensure error messages are clear.
Tests 
Add tests in test_users_api and test_user_schemas for edge cases.