### PR TITLE
Feature/nickname edge cases

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -42,14 +42,19 @@ class UserCreate(UserBase):
     password: str = Field(..., example="Secure*1234")
     nickname: Optional[str] = Field(None, min_length=3, max_length=50, pattern=r'^[\w-]+$', example=generate_nickname())
 
-    @validator("nickname", pre=True)
-    def validate_nickname(cls, value):
-        if value:
-            reserved_words = ["admin", "root", "system"]
-            if value.lower() in reserved_words:
-                raise ValueError("Nickname cannot be a reserved word")
+    @validator("password")
+    def validate_password(cls, value):
+        if len(value) < 8:
+            raise ValueError("Password must be at least 8 characters long")
+        if not re.search(r"[A-Z]", value):
+            raise ValueError("Password must contain at least one uppercase letter")
+        if not re.search(r"[a-z]", value):
+            raise ValueError("Password must contain at least one lowercase letter")
+        if not re.search(r"\d", value):
+            raise ValueError("Password must contain at least one digit")
+        if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", value):
+            raise ValueError("Password must contain at least one special character")
         return value
-
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -37,10 +37,13 @@ class UserBase(BaseModel):
     class Config:
         from_attributes = True
 
+
+
+
 class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., example="Secure*1234")
-    nickname: Optional[str] = Field(None, min_length=3, max_length=50, pattern=r'^[\w-]+$', example=generate_nickname())
+    nickname: Optional[str] = Field(None, min_length=3, max_length=50, pattern=r'^\w[\w-]*\w$', example=generate_nickname())
 
     @validator("password")
     def validate_password(cls, value):
@@ -58,7 +61,7 @@ class UserCreate(UserBase):
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")
-    nickname: Optional[str] = Field(None, min_length=3, max_length=50, pattern=r'^[\w-]+$', example="john_doe123")
+    nickname: Optional[str] = Field(None, min_length=3, max_length=50, pattern=r'^\w[\w-]*\w$', example="john_doe123")
     # ... other fields ...
     first_name: Optional[str] = Field(None, example="John")
     last_name: Optional[str] = Field(None, example="Doe")

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -40,16 +40,36 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., example="Secure*1234")
+    nickname: Optional[str] = Field(None, min_length=3, max_length=50, pattern=r'^[\w-]+$', example=generate_nickname())
+
+    @validator("nickname", pre=True)
+    def validate_nickname(cls, value):
+        if value:
+            reserved_words = ["admin", "root", "system"]
+            if value.lower() in reserved_words:
+                raise ValueError("Nickname cannot be a reserved word")
+        return value
+
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")
-    nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example="john_doe123")
+    nickname: Optional[str] = Field(None, min_length=3, max_length=50, pattern=r'^[\w-]+$', example="john_doe123")
+    # ... other fields ...
     first_name: Optional[str] = Field(None, example="John")
     last_name: Optional[str] = Field(None, example="Doe")
     bio: Optional[str] = Field(None, example="Experienced software developer specializing in web applications.")
     profile_picture_url: Optional[str] = Field(None, example="https://example.com/profiles/john.jpg")
     linkedin_profile_url: Optional[str] =Field(None, example="https://linkedin.com/in/johndoe")
     github_profile_url: Optional[str] = Field(None, example="https://github.com/johndoe")
+
+
+    @validator("nickname", pre=True)
+    def validate_nickname(cls, value):
+        if value:
+            reserved_words = ["admin", "root", "system"]
+            if value.lower() in reserved_words:
+                raise ValueError("Nickname cannot be a reserved word")
+        return value
 
     @root_validator(pre=True)
     def check_at_least_one_value(cls, values):

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -213,3 +213,15 @@ async def test_create_user_too_long_nickname(async_client, admin_token):
     response = await async_client.post("/users/", json=invalid_data, headers=headers)
     assert response.status_code == 422
     assert "String should have at most 50 characters" in response.json()["detail"][0]["msg"]
+
+@pytest.mark.asyncio
+async def test_create_user_weak_password(async_client, admin_token):
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    invalid_data = {
+        "email": "test@example.com",
+        "password": "weak",  # Too short
+        "nickname": "test_user"
+    }
+    response = await async_client.post("/users/", json=invalid_data, headers=headers)
+    assert response.status_code == 422
+    assert "Password must be at least 8 characters long" in response.json()["detail"][0]["msg"]

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -189,3 +189,27 @@ async def test_list_users_unauthorized(async_client, user_token):
         headers={"Authorization": f"Bearer {user_token}"}
     )
     assert response.status_code == 403  # Forbidden, as expected for regular user
+
+@pytest.mark.asyncio
+async def test_create_user_invalid_nickname(async_client, admin_token):
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    invalid_data = {
+        "email": "test@example.com",
+        "password": "Secure*1234",
+        "nickname": "admin"  # Reserved word
+    }
+    response = await async_client.post("/users/", json=invalid_data, headers=headers)
+    assert response.status_code == 422
+    assert "Nickname cannot be a reserved word" in response.json()["detail"][0]["msg"]
+
+@pytest.mark.asyncio
+async def test_create_user_too_long_nickname(async_client, admin_token):
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    invalid_data = {
+        "email": "test@example.com",
+        "password": "Secure*1234",
+        "nickname": "a" * 51  # Exceeds max length
+    }
+    response = await async_client.post("/users/", json=invalid_data, headers=headers)
+    assert response.status_code == 422
+    assert "String should have at most 50 characters" in response.json()["detail"][0]["msg"]

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -224,4 +224,30 @@ async def test_create_user_weak_password(async_client, admin_token):
     }
     response = await async_client.post("/users/", json=invalid_data, headers=headers)
     assert response.status_code == 422
-    assert "Password must be at least 8 characters long" in response.json()["detail"][0]["msg"]
+    assert "Password must be at least 8 characters long" in response.json()["detail"][0]["msg"] 
+
+@pytest.mark.asyncio
+async def test_update_user_bio_only(async_client, admin_user, admin_token):
+    updated_data = {"bio": "Updated bio"}
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
+    assert response.status_code == 200
+    assert response.json()["bio"] == "Updated bio"
+    assert response.json()["profile_picture_url"] == admin_user.profile_picture_url
+
+@pytest.mark.asyncio
+async def test_update_user_profile_picture_only(async_client, admin_user, admin_token):
+    updated_data = {"profile_picture_url": "https://example.com/new.jpg"}
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
+    assert response.status_code == 200
+    assert response.json()["profile_picture_url"] == "https://example.com/new.jpg"
+    assert response.json()["bio"] == admin_user.bio
+
+@pytest.mark.asyncio
+async def test_update_user_invalid_url(async_client, admin_user, admin_token):
+    updated_data = {"profile_picture_url": "invalid_url"}
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
+    assert response.status_code == 422
+    assert "Invalid URL format" in response.json()["detail"][0]["msg"]

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -78,3 +78,9 @@ def test_user_create_too_long_nickname(user_create_data):
     user_create_data["nickname"] = "a" * 51
     with pytest.raises(ValidationError):
         UserCreate(**user_create_data)
+
+@pytest.mark.parametrize("password", ["short", "nouppercase123!", "NOLOWERCASE123!", "NoDigits!", "NoSpecial123"])
+def test_user_create_invalid_password(password, user_create_data):
+    user_create_data["password"] = password
+    with pytest.raises(ValidationError):
+        UserCreate(**user_create_data)

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -84,3 +84,9 @@ def test_user_create_invalid_password(password, user_create_data):
     user_create_data["password"] = password
     with pytest.raises(ValidationError):
         UserCreate(**user_create_data)
+    
+@pytest.mark.parametrize("nickname", ["-test-", "_test_", "test--test", "test__test"])
+def test_user_create_invalid_nickname_format(nickname, user_create_data):
+    user_create_data["nickname"] = nickname
+    with pytest.raises(ValidationError):
+        UserCreate(**user_create_data)

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -67,3 +67,14 @@ def test_user_base_invalid_email(user_base_data_invalid):
     
     assert "value is not a valid email address" in str(exc_info.value)
     assert "john.doe.example.com" in str(exc_info.value)
+
+@pytest.mark.parametrize("nickname", ["admin", "root", "system"])
+def test_user_create_reserved_nickname(nickname, user_create_data):
+    user_create_data["nickname"] = nickname
+    with pytest.raises(ValidationError):
+        UserCreate(**user_create_data)
+
+def test_user_create_too_long_nickname(user_create_data):
+    user_create_data["nickname"] = "a" * 51
+    with pytest.raises(ValidationError):
+        UserCreate(**user_create_data)


### PR DESCRIPTION
Problem :
Ensure usernames don’t contain leading/trailing hyphens or underscores, which could cause issues in URLs or display.

Solution :
Modify Schema
Update the nickname regex in UserCreate and UserUpdate.

Tests: 
Add tests for invalid nicknames.