### PR TITLE
❇️ Add password validation

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -24,7 +24,7 @@ def validate_url(url: Optional[str]) -> Optional[str]:
 
 class UserBase(BaseModel):
     email: EmailStr = Field(..., example="john.doe@example.com")
-    nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example=generate_nickname())
+    nickname: Optional[str] = Field(None, min_length=3, max_length=30, example=generate_nickname())
     first_name: Optional[str] = Field(None, example="John")
     last_name: Optional[str] = Field(None, example="Doe")
     bio: Optional[str] = Field(None, example="Experienced software developer specializing in web applications.")
@@ -33,7 +33,13 @@ class UserBase(BaseModel):
     github_profile_url: Optional[str] = Field(None, example="https://github.com/johndoe")
 
     _validate_urls = validator('profile_picture_url', 'linkedin_profile_url', 'github_profile_url', pre=True, allow_reuse=True)(validate_url)
- 
+
+    @validator('nickname')
+    def validate_nickname_format(cls, value):
+        if value and not re.match(r'^[a-zA-Z0-9_-]+$', value):
+            raise ValueError('Nickname must be 3-30 characters and contain only letters, numbers, underscores, or hyphens.')
+        return value
+
     class Config:
         from_attributes = True
 

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -47,6 +47,21 @@ class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., example="Secure*1234")
 
+    @validator('password')
+    def validate_password(cls, value):
+        if len(value) < 8:
+            raise ValueError("Password must be at least 8 characters long.")
+        if not re.search(r"[A-Z]", value):
+            raise ValueError("Password must include at least one uppercase letter.")
+        if not re.search(r"[a-z]", value):
+            raise ValueError("Password must include at least one lowercase letter.")
+        if not re.search(r"[0-9]", value):
+            raise ValueError("Password must include at least one number.")
+        if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", value):
+            raise ValueError("Password must include at least one special character.")
+        return value
+
+
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")
     nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example="john_doe123")
@@ -56,6 +71,23 @@ class UserUpdate(UserBase):
     profile_picture_url: Optional[str] = Field(None, example="https://example.com/profiles/john.jpg")
     linkedin_profile_url: Optional[str] =Field(None, example="https://linkedin.com/in/johndoe")
     github_profile_url: Optional[str] = Field(None, example="https://github.com/johndoe")
+    password: Optional[str] = Field(None, example="Secure*1234")  # Add this if not already present
+
+    @validator('password')
+    def validate_password(cls, value):
+        if value is None:
+            return value
+        if len(value) < 8:
+            raise ValueError("Password must be at least 8 characters long.")
+        if not re.search(r"[A-Z]", value):
+            raise ValueError("Password must include at least one uppercase letter.")
+        if not re.search(r"[a-z]", value):
+            raise ValueError("Password must include at least one lowercase letter.")
+        if not re.search(r"[0-9]", value):
+            raise ValueError("Password must include at least one number.")
+        if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", value):
+            raise ValueError("Password must include at least one special character.")
+        return value
 
     @root_validator(pre=True)
     def check_at_least_one_value(cls, values):

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -67,3 +67,23 @@ def test_user_base_invalid_email(user_base_data_invalid):
     
     assert "value is not a valid email address" in str(exc_info.value)
     assert "john.doe.example.com" in str(exc_info.value)
+
+def test_password_too_short():
+    with pytest.raises(ValidationError):
+        UserCreate(email="test@example.com", password="Short1!", nickname="user123")
+
+def test_password_no_uppercase():
+    with pytest.raises(ValidationError):
+        UserCreate(email="test@example.com", password="lowercase1!", nickname="user123")
+
+def test_password_no_number():
+    with pytest.raises(ValidationError):
+        UserCreate(email="test@example.com", password="Password!", nickname="user123")
+
+def test_password_no_special_char():
+    with pytest.raises(ValidationError):
+        UserCreate(email="test@example.com", password="Password1", nickname="user123")
+
+def test_password_valid():
+    user = UserCreate(email="test@example.com", password="StrongPass1!", nickname="user123")
+    assert user.password == "StrongPass1!"

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -158,3 +158,13 @@ async def test_unlock_user_account(db_session, locked_user):
     assert unlocked, "The account should be unlocked"
     refreshed_user = await UserService.get_by_id(db_session, locked_user.id)
     assert not refreshed_user.is_locked, "The user should no longer be locked"
+
+@pytest.mark.asyncio
+async def test_create_user_weak_password(async_client):
+    payload = {
+        "email": "weak@example.com",
+        "password": "weakpass",  # Missing complexity
+        "nickname": "weakuser"
+    }
+    response = await async_client.post("/register/", json=payload)
+    assert response.status_code == 422

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -10,6 +10,7 @@ pytestmark = pytest.mark.asyncio
 # Test creating a user with valid data
 async def test_create_user_with_valid_data(db_session, email_service):
     user_data = {
+        "nickname": "valid_user",  # ✅ Add this
         "email": "valid_user@example.com",
         "password": "ValidPassword123!",
     }
@@ -20,9 +21,9 @@ async def test_create_user_with_valid_data(db_session, email_service):
 # Test creating a user with invalid data
 async def test_create_user_with_invalid_data(db_session, email_service):
     user_data = {
-        "nickname": "",  # Invalid nickname
-        "email": "invalidemail",  # Invalid email
-        "password": "short",  # Invalid password
+        "nickname": "",  # invalid
+        "email": "registerinvalidemail",  # invalid
+        "password": "short",  # invalid
     }
     user = await UserService.create(db_session, user_data, email_service)
     assert user is None
@@ -92,8 +93,9 @@ async def test_list_users_with_pagination(db_session, users_with_same_role_50_us
 # Test registering a user with valid data
 async def test_register_user_with_valid_data(db_session, email_service):
     user_data = {
-        "email": "register_valid_user@example.com",
-        "password": "RegisterValid123!",
+    "nickname": "valid_user",  # ✅ Add this
+    "email": "valid_user@example.com",
+    "password": "ValidPassword123!",
     }
     user = await UserService.register_user(db_session, user_data, email_service)
     assert user is not None


### PR DESCRIPTION
Issue 2: Password Complexity Validation
Description:
Previously, the API allowed weak passwords without enforcing any security standards, increasing the likelihood of user accounts being compromised.

Fix Implemented:

- Added a @validator to the UserCreate schema to enforce strong password policies.
- Password validation rules implemented:
- Minimum length of 8 characters 
- Must include at least one uppercase letter, one lowercase letter, one digit, and one special character
- Weak passwords now trigger a 422 Unprocessable Entity response.
- Developed test cases to ensure:
- Strong passwords pass validation
- Weak or simple passwords are correctly rejected